### PR TITLE
Feature/#59 bootsfaces renderers

### DIFF
--- a/Sosit18/src/java/controller/InitBootsfacesBean.java
+++ b/Sosit18/src/java/controller/InitBootsfacesBean.java
@@ -1,0 +1,80 @@
+package controller;
+import static com.sun.xml.ws.spi.db.BindingContextFactory.LOGGER;
+import java.util.logging.Level;
+import javax.enterprise.context.ApplicationScoped;
+import javax.faces.bean.ManagedBean;
+import javax.faces.component.UIComponentBase;
+import javax.faces.render.Renderer;
+import net.bootsfaces.component.ComponentsEnum;
+
+@ManagedBean(eager=true)
+@ApplicationScoped
+public class InitBootsfacesBean {
+    /**
+     * Register the Bootsfaces renderers
+     * https://beyondjava.net/running-bootsfaces-on-glassfish-or-payara
+     */
+    private void initializeBootsfacesRenderers() {
+        
+        // Loop through all of the Bootsfaces components
+        for (ComponentsEnum value : ComponentsEnum.values()) {
+            
+            // Get the component class information
+            String className;
+            
+            // switchComponent has wrong classpath in ComponentsEnum
+            if (value.name().equals("switchComponent")) {
+                // Use correct qualified name
+                className = "net.bootsfaces.component.switchComponent.Switch";
+            } else {
+                // Otherwise, use specified value
+                className = value.classname();
+            }
+            
+            // See if this is an internal reference
+            if (className.contains("Internal")) {
+                LOGGER.log(Level.INFO, "Init Bootsfaces: Skipping internal component: " + className);
+            } else {
+                
+                LOGGER.log(Level.INFO, "Init Bootsfaces: Processing component: " + className);
+                
+                try {
+                     // See if we can instantiate the class
+                    Class componentClass = Class.forName(className);
+                    Class<UIComponentBase> baseClass = componentClass.asSubclass(UIComponentBase.class);
+                    UIComponentBase component = baseClass.newInstance();
+                    String rendererFamily = component.getFamily();
+                    String rendererType = component.getRendererType();
+
+                    // Determine the renderer class name
+                    String simpleName = componentClass.getSimpleName();
+                    String rendererClassName;
+                    switch (simpleName) {
+                        case "NavCommandLink":
+                            // Shares same renderer with NavLink
+                            rendererClassName = "net.bootsfaces.component.navLink.NavLinkRenderer";
+                            break;
+                        default:
+                            // We have to guess at the name of the renderer
+                            rendererClassName = className + "Renderer";
+                    }
+                    
+                    // Look up the renderer
+                    Class rendererSuperclass = Class.forName(rendererClassName);
+                    Class<Renderer> rendererClass = rendererSuperclass.asSubclass(Renderer.class);
+                    Renderer renderer = rendererClass.newInstance();
+                    LOGGER.log(Level.INFO, "Init Bootsfaces: Registering renderer: " + rendererFamily + "/" + rendererType);
+
+                    // ****** THIS IS THE IMPORTANT CALL TO REGISTER THE RENDERER *********
+                    addRenderer(rendererFamily, rendererType, renderer);
+                } catch (Throwable e) {
+                    LOGGER.log(Level.WARNING, "Init Bootsfaces: Unable to register renderer for component: " + className, e);
+                }
+           }
+        }
+    }
+
+    public void addRenderer(String family, String rendererType, Renderer renderer) {
+        getDefaultRenderKit().addRenderer(family, rendererType, renderer);
+    }
+}

--- a/Sosit18/src/java/controller/InitBootsfacesBean.java
+++ b/Sosit18/src/java/controller/InitBootsfacesBean.java
@@ -14,6 +14,10 @@ import javax.faces.render.RenderKitFactory;
 import javax.faces.render.Renderer;
 import net.bootsfaces.component.ComponentsEnum;
 
+/**
+ * Register the Bootsfaces renderers
+ * https://beyondjava.net/running-bootsfaces-on-glassfish-or-payara
+ */
 @ApplicationScoped
 @Named
 public class InitBootsfacesBean {
@@ -24,11 +28,9 @@ public class InitBootsfacesBean {
         initializeBootsfacesRenderers();
     }
 
-    /**
-     * Register the Bootsfaces renderers
-     * https://beyondjava.net/running-bootsfaces-on-glassfish-or-payara
-     */
     private void initializeBootsfacesRenderers() {
+        int componentsTotal = 0;
+        int renderersAddedCount = 0;
 
         // Loop through all of the Bootsfaces components
         for (ComponentsEnum value : ComponentsEnum.values()) {
@@ -51,6 +53,7 @@ public class InitBootsfacesBean {
             } else {
 
                 LOGGER.log(Level.INFO, "Init Bootsfaces: Processing component: {0}", className);
+                componentsTotal++;
 
                 try {
                     // See if we can instantiate the class
@@ -79,13 +82,15 @@ public class InitBootsfacesBean {
                     Renderer renderer = rendererClass.newInstance();
                     LOGGER.log(Level.INFO, "Init Bootsfaces: Registering renderer: {0}/{1}", new Object[]{rendererFamily, rendererType});
 
-                    // ****** THIS IS THE IMPORTANT CALL TO REGISTER THE RENDERER *********
                     addRenderer(rendererFamily, rendererType, renderer);
+                    // ****** THIS IS THE IMPORTANT CALL TO REGISTER THE RENDERER *********
+                    renderersAddedCount++;
                 } catch (Throwable e) {
                     LOGGER.log(Level.WARNING, "Init Bootsfaces: Unable to register renderer for component: " + className, e);
                 }
             }
         }
+        LOGGER.log(Level.INFO, "Init Bootsfaces: registered renderers/total components : {0}/{1}", new Object[]{renderersAddedCount, componentsTotal});
     }
 
     public void addRenderer(String family, String rendererType, Renderer renderer) {

--- a/Sosit18/src/java/controller/InitBootsfacesBean.java
+++ b/Sosit18/src/java/controller/InitBootsfacesBean.java
@@ -1,27 +1,41 @@
 package controller;
+
 import static com.sun.xml.ws.spi.db.BindingContextFactory.LOGGER;
 import java.util.logging.Level;
 import javax.enterprise.context.ApplicationScoped;
-import javax.faces.bean.ManagedBean;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
+import javax.faces.FactoryFinder;
+import javax.inject.Named;
 import javax.faces.component.UIComponentBase;
+import javax.faces.context.FacesContext;
+import javax.faces.render.RenderKit;
+import javax.faces.render.RenderKitFactory;
 import javax.faces.render.Renderer;
 import net.bootsfaces.component.ComponentsEnum;
 
-@ManagedBean(eager=true)
 @ApplicationScoped
+@Named
 public class InitBootsfacesBean {
+
+    private RenderKit defaultRenderKit = null;
+
+    public void startup(@Observes @Initialized(ApplicationScoped.class) Object context) {
+        initializeBootsfacesRenderers();
+    }
+
     /**
      * Register the Bootsfaces renderers
      * https://beyondjava.net/running-bootsfaces-on-glassfish-or-payara
      */
     private void initializeBootsfacesRenderers() {
-        
+
         // Loop through all of the Bootsfaces components
         for (ComponentsEnum value : ComponentsEnum.values()) {
-            
+
             // Get the component class information
             String className;
-            
+
             // switchComponent has wrong classpath in ComponentsEnum
             if (value.name().equals("switchComponent")) {
                 // Use correct qualified name
@@ -30,16 +44,16 @@ public class InitBootsfacesBean {
                 // Otherwise, use specified value
                 className = value.classname();
             }
-            
+
             // See if this is an internal reference
             if (className.contains("Internal")) {
-                LOGGER.log(Level.INFO, "Init Bootsfaces: Skipping internal component: " + className);
+                LOGGER.log(Level.INFO, "Init Bootsfaces: Skipping internal component: {0}", className);
             } else {
-                
-                LOGGER.log(Level.INFO, "Init Bootsfaces: Processing component: " + className);
-                
+
+                LOGGER.log(Level.INFO, "Init Bootsfaces: Processing component: {0}", className);
+
                 try {
-                     // See if we can instantiate the class
+                    // See if we can instantiate the class
                     Class componentClass = Class.forName(className);
                     Class<UIComponentBase> baseClass = componentClass.asSubclass(UIComponentBase.class);
                     UIComponentBase component = baseClass.newInstance();
@@ -58,23 +72,35 @@ public class InitBootsfacesBean {
                             // We have to guess at the name of the renderer
                             rendererClassName = className + "Renderer";
                     }
-                    
+
                     // Look up the renderer
                     Class rendererSuperclass = Class.forName(rendererClassName);
                     Class<Renderer> rendererClass = rendererSuperclass.asSubclass(Renderer.class);
                     Renderer renderer = rendererClass.newInstance();
-                    LOGGER.log(Level.INFO, "Init Bootsfaces: Registering renderer: " + rendererFamily + "/" + rendererType);
+                    LOGGER.log(Level.INFO, "Init Bootsfaces: Registering renderer: {0}/{1}", new Object[]{rendererFamily, rendererType});
 
                     // ****** THIS IS THE IMPORTANT CALL TO REGISTER THE RENDERER *********
                     addRenderer(rendererFamily, rendererType, renderer);
                 } catch (Throwable e) {
                     LOGGER.log(Level.WARNING, "Init Bootsfaces: Unable to register renderer for component: " + className, e);
                 }
-           }
+            }
         }
     }
 
     public void addRenderer(String family, String rendererType, Renderer renderer) {
         getDefaultRenderKit().addRenderer(family, rendererType, renderer);
+    }
+
+    /*
+     * From org.primefaces.mobile.renderkit.MobileRenderKit
+     */
+    private RenderKit getDefaultRenderKit() {
+        if (defaultRenderKit == null) {
+            RenderKitFactory renderKitFactory = (RenderKitFactory) FactoryFinder.getFactory(FactoryFinder.RENDER_KIT_FACTORY);
+            FacesContext facesContext = FacesContext.getCurrentInstance();
+            defaultRenderKit = renderKitFactory.getRenderKit(facesContext, RenderKitFactory.HTML_BASIC_RENDER_KIT);
+        }
+        return defaultRenderKit;
     }
 }


### PR DESCRIPTION
Dit lost het probleem op dat soms Glassfish opstart en een witte pagina toont met enkel tekst.

Dit komt omdat soms Glassfish de classpath niet scant bij het opstarten en dus de bootfaces-jar niet gebruikt. Onze bootsfaces tags worden dan niet gerendered.

De oplossing is zelf al de bootsfaces elementen te registreren. `InitBootsfacesBean.initializeBootsfacesRenderers` wordt dan bij elke startup gecalled en zal alle componenten onder `net.bootsfaces.component.ComponentsEnum` toevoegen.

De oplossing heb ik hier gevonden:  #https://github.com/TheCoder4eu/BootsFaces-OSP/issues/732
Samengevat op deze blog: [beyondjava.net/running-bootsfaces-on-glassfish-or-payara](https://beyondjava.net/running-bootsfaces-on-glassfish-or-payara)

PS: Bij mij kan het niet alle componenten registreren. Ik krijg nog als boodschap: `Init Bootsfaces: registered renderers/total components : 68/78`