### PR TITLE
asset page: Save button krijgt geen ID meer mee van geëdite asset

### DIFF
--- a/Sosit18/web/asset.xhtml
+++ b/Sosit18/web/asset.xhtml
@@ -127,7 +127,6 @@
                         <div class="text-center">
                             <b:commandButton value="Save" icon="save" look="success" style-class="save"
                                              action="#{assetController.createNewAsset()}">
-                                <f:param name="ID" value="#{assetController.assetidSelected}"/>
                             </b:commandButton>
                             <b:button value="Cancel" look="warning" style-class="cancel"
                                       outcome="assetList"/>


### PR DESCRIPTION
Dit is null bij nieuw asset. 
De ID werd meegegeven om te proberen de ID in de url te houden 
bij validation error. Dit werkte niet.
Deze fix verwijderd de param in de save button.